### PR TITLE
Add PGP key claim support

### DIFF
--- a/apps/keytrace.dev/components/ui/ClaimCard.vue
+++ b/apps/keytrace.dev/components/ui/ClaimCard.vue
@@ -32,8 +32,23 @@
 
     <!-- Body -->
     <div class="px-4 py-3 space-y-1.5">
+      <!-- PGP fingerprint display -->
+      <template v-if="isPgp">
+        <div class="font-mono text-xs text-zinc-400 break-all leading-relaxed">{{ formattedFingerprint }}</div>
+        <div class="text-xs text-zinc-500">Key ID: {{ shortFingerprint }}</div>
+        <a
+          v-if="claim.identity?.profileUrl"
+          :href="claim.identity.profileUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-xs text-violet-400 hover:text-violet-300 transition-colors"
+        >
+          View proof
+        </a>
+      </template>
+      <!-- Standard profile URL display -->
       <a
-        v-if="claim.identity?.profileUrl || claim.subject"
+        v-else-if="claim.identity?.profileUrl || claim.subject"
         :href="claim.identity?.profileUrl || claim.subject"
         target="_blank"
         rel="noopener noreferrer"
@@ -80,7 +95,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { Github, Globe, AtSign, Key } from "lucide-vue-next";
+import { Github, Globe, AtSign, Key, Shield } from "lucide-vue-next";
 import NpmIcon from "~/components/icons/NpmIcon.vue";
 import TangledIcon from "~/components/icons/TangledIcon.vue";
 
@@ -124,9 +139,27 @@ const serviceIcons: Record<string, any> = {
   fediverse: AtSign,
   npm: NpmIcon,
   tangled: TangledIcon,
+  pgp: Shield,
 };
 
 const serviceIcon = computed(() => serviceIcons[props.claim.serviceType ?? ""] ?? Key);
+
+const isPgp = computed(() => props.claim.serviceType === "pgp");
+
+const formattedFingerprint = computed(() => {
+  const raw = (props.claim.identity?.subject ?? "").replace(/\s+/g, "").toUpperCase();
+  if (!raw || raw.length < 8) return raw;
+  // Format as 4-char groups with double space at midpoint
+  const groups = raw.match(/.{1,4}/g) ?? [];
+  const mid = Math.ceil(groups.length / 2);
+  return groups.slice(0, mid).join(" ") + "  " + groups.slice(mid).join(" ");
+});
+
+const shortFingerprint = computed(() => {
+  const raw = (props.claim.identity?.subject ?? "").replace(/\s+/g, "").toUpperCase();
+  // Last 16 chars = 64-bit key ID
+  return raw.length >= 16 ? raw.slice(-16) : raw;
+});
 
 const statusClasses = computed(() => {
   switch (props.claim.status) {

--- a/apps/keytrace.dev/pages/[handle].vue
+++ b/apps/keytrace.dev/pages/[handle].vue
@@ -165,6 +165,7 @@ function guessDisplayName(uri: string) {
   if (uri.includes("github.com")) return "GitHub Account";
   if (uri.startsWith("dns:")) return "Domain";
   if (uri.includes("mastodon")) return "Mastodon Account";
+  if (uri.startsWith("pgp:")) return "PGP Key";
   return "Identity Claim";
 }
 
@@ -172,6 +173,7 @@ function guessServiceType(uri: string) {
   if (uri.includes("github.com")) return "github";
   if (uri.startsWith("dns:")) return "dns";
   if (uri.includes("mastodon")) return "mastodon";
+  if (uri.startsWith("pgp:")) return "pgp";
   return "";
 }
 

--- a/apps/keytrace.dev/pages/add/index.vue
+++ b/apps/keytrace.dev/pages/add/index.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script setup lang="ts">
-import { Github, Globe, AtSign, Cloud } from "lucide-vue-next";
+import { Github, Globe, AtSign, Cloud, Shield } from "lucide-vue-next";
 import NpmIcon from "~/components/icons/NpmIcon.vue";
 import TangledIcon from "~/components/icons/TangledIcon.vue";
 import type { ServiceOption } from "~/components/ui/ServicePicker.vue";
@@ -39,6 +39,7 @@ const iconMap: Record<string, unknown> = {
   cloud: Cloud,
   npm: NpmIcon,
   tangled: TangledIcon,
+  shield: Shield,
 };
 
 // Transform API response into ServiceOption format

--- a/apps/keytrace.dev/pages/dashboard.vue
+++ b/apps/keytrace.dev/pages/dashboard.vue
@@ -103,7 +103,7 @@
 </template>
 
 <script setup lang="ts">
-import { Plus as PlusIcon, AlertCircle as AlertCircleIcon, Link as LinkIcon, RefreshCw as RefreshCwIcon, Trash2 as Trash2Icon, Ban as BanIcon, Github, Globe, AtSign, Key } from "lucide-vue-next";
+import { Plus as PlusIcon, AlertCircle as AlertCircleIcon, Link as LinkIcon, RefreshCw as RefreshCwIcon, Trash2 as Trash2Icon, Ban as BanIcon, Github, Globe, AtSign, Key, Shield } from "lucide-vue-next";
 import type { Component } from "vue";
 
 const { session } = useSession();
@@ -126,12 +126,14 @@ const serviceIcons: Record<string, Component> = {
   domain: Globe,
   dns: Globe,
   mastodon: AtSign,
+  pgp: Shield,
 };
 
 function getServiceIcon(uri: string): Component {
   if (uri.includes("github.com")) return serviceIcons.github;
   if (uri.startsWith("dns:")) return serviceIcons.dns;
   if (uri.includes("mastodon")) return serviceIcons.mastodon;
+  if (uri.startsWith("pgp:")) return serviceIcons.pgp;
   return Key;
 }
 

--- a/packages/lexicon/lexicons/dev/keytrace/claim.json
+++ b/packages/lexicon/lexicons/dev/keytrace/claim.json
@@ -12,7 +12,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "knownValues": ["github", "dns", "mastodon", "twitter", "website"],
+            "knownValues": ["github", "dns", "mastodon", "twitter", "website", "pgp"],
             "description": "The claim type identifier"
           },
           "claimUri": {

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -53,7 +53,7 @@ export { COLLECTION_NSID, DEFAULT_TIMEOUT, PUBLIC_API_URL, PLC_DIRECTORY_URL } f
 
 // Service providers
 export * as serviceProviders from "./serviceProviders/index.js";
-export type { ServiceProvider, ServiceProviderMatch, ServiceProviderUI, ProofTarget, ProofRequest, ProcessedURI } from "./serviceProviders/types.js";
+export type { ServiceProvider, ServiceProviderMatch, ServiceProviderUI, ExtraInput, ProofTarget, ProofRequest, ProcessedURI } from "./serviceProviders/types.js";
 
 // Fetchers
 export * as fetchers from "./fetchers/index.js";

--- a/packages/runner/src/serviceProviders/index.ts
+++ b/packages/runner/src/serviceProviders/index.ts
@@ -4,9 +4,10 @@ import activitypub from "./activitypub.js";
 import bsky from "./bsky.js";
 import npm from "./npm.js";
 import tangled from "./tangled.js";
+import pgp from "./pgp.js";
 import type { ServiceProvider, ServiceProviderMatch } from "./types.js";
 
-export type { ServiceProvider, ServiceProviderMatch, ServiceProviderUI, ProofTarget, ProofRequest, ProcessedURI } from "./types.js";
+export type { ServiceProvider, ServiceProviderMatch, ServiceProviderUI, ExtraInput, ProofTarget, ProofRequest, ProcessedURI } from "./types.js";
 
 const providers: Record<string, ServiceProvider> = {
   github,
@@ -15,6 +16,7 @@ const providers: Record<string, ServiceProvider> = {
   bsky,
   npm,
   tangled,
+  pgp,
 };
 
 /**
@@ -64,4 +66,4 @@ export function getProofTextForProvider(providerId: string, did: string, handle?
   return provider?.getProofText(did, handle);
 }
 
-export { github, dns, activitypub, bsky, npm, tangled };
+export { github, dns, activitypub, bsky, npm, tangled, pgp };

--- a/packages/runner/src/serviceProviders/pgp.ts
+++ b/packages/runner/src/serviceProviders/pgp.ts
@@ -1,0 +1,181 @@
+import type { ServiceProvider } from "./types.js";
+
+/**
+ * PGP Key service provider
+ *
+ * Users prove ownership of a PGP key by clearsigning a proof message
+ * containing their DID and fingerprint, then hosting it at a URL.
+ * The claim URI format is: pgp:https://...
+ *
+ * Supported proof hosting:
+ * - GitHub Gists (fetches via API)
+ * - Tangled Strings (fetches raw content)
+ * - Any other HTTPS URL (fetches as plain text)
+ */
+const pgp: ServiceProvider = {
+  id: "pgp",
+  name: "PGP Key",
+  homepage: "https://www.openpgp.org",
+
+  // Match pgp: prefixed URLs
+  reUri: /^pgp:(https:\/\/.+)$/,
+
+  isAmbiguous: false,
+
+  ui: {
+    description: "Prove ownership of a PGP key",
+    icon: "shield",
+    inputLabel: "Proof URL",
+    inputPlaceholder: "https://gist.github.com/username/abc123...",
+    instructions: [
+      "Install [GPG tools](https://gist.github.com/jfrobbins/5c2dbceb81c33afc5b0bcbe0d3343692#1-installing-gpg)",
+      "Enter your PGP fingerprint to set up the proof (run `gpg --fingerprint` to find it)",
+      "Copy the proof text and save it to a file (e.g. `proof.txt`)",
+      "Clearsign the file with your PGP key: `gpg --clearsign proof.txt`",
+      "Host the signed output (`proof.txt.asc`) at a public URL — a [GitHub Gist](https://gist.github.com) or [Tangled String](https://tangled.org/strings/new) works well",
+      "Paste the URL below",
+    ],
+    proofTemplate: "Verifying my PGP key on keytrace\n\ndid: {did}\nfingerprint: {fingerprint}",
+    extraInputs: [
+      {
+        key: "fingerprint",
+        label: "PGP Fingerprint",
+        placeholder: "AB12 CD34 EF56 7890 1234  5678 9ABC DEF0 1234 5678",
+        pattern: "^[A-Fa-f0-9 ]{16,}$",
+        patternError: "Enter a valid PGP fingerprint (hex characters)",
+      },
+    ],
+  },
+
+  processURI(uri, match) {
+    const [, proofUrl] = match;
+
+    // Detect hosting platform to choose fetch strategy
+    const gistMatch = proofUrl.match(/^https:\/\/gist\.github\.com\/([^/]+)\/([a-f0-9]+)\/?$/);
+    const tangledMatch = proofUrl.match(/^https:\/\/tangled\.org\/strings\/([^/]+)\/([a-z0-9]+)\/?$/);
+
+    if (gistMatch) {
+      const [, , gistId] = gistMatch;
+      return {
+        profile: {
+          display: "PGP Key",
+          uri: proofUrl,
+        },
+        proof: {
+          request: {
+            uri: `https://api.github.com/gists/${gistId}`,
+            fetcher: "http",
+            format: "json",
+            options: {
+              headers: { Accept: "application/vnd.github.v3+json" },
+            },
+          },
+          target: [{ path: ["files", "*", "content"], relation: "contains", format: "text" }],
+        },
+      };
+    }
+
+    if (tangledMatch) {
+      const [, username, stringId] = tangledMatch;
+      return {
+        profile: {
+          display: "PGP Key",
+          uri: proofUrl,
+        },
+        proof: {
+          request: {
+            uri: `https://tangled.org/strings/${username}/${stringId}/raw`,
+            fetcher: "http",
+            format: "text",
+          },
+          target: [{ path: [], relation: "contains", format: "text" }],
+        },
+      };
+    }
+
+    // Generic URL: fetch as plain text
+    return {
+      profile: {
+        display: "PGP Key",
+        uri: proofUrl,
+      },
+      proof: {
+        request: {
+          uri: proofUrl,
+          fetcher: "http",
+          format: "text",
+        },
+        target: [{ path: [], relation: "contains", format: "text" }],
+      },
+    };
+  },
+
+  postprocess(data, match) {
+    const [, proofUrl] = match;
+
+    // Try to extract fingerprint from the proof text
+    let text = "";
+    if (typeof data === "string") {
+      text = data;
+    } else if (data && typeof data === "object") {
+      // For gist JSON, search through file contents
+      const gist = data as { files?: Record<string, { content?: string }>; owner?: { avatar_url?: string; login?: string } };
+      if (gist.files) {
+        for (const file of Object.values(gist.files)) {
+          if (file.content) {
+            text += file.content + "\n";
+          }
+        }
+      }
+    }
+
+    const fpMatch = text.match(/fingerprint:\s*([A-Fa-f0-9 ]{16,})/);
+    const fingerprint = fpMatch ? fpMatch[1].replace(/\s+/g, "").toLowerCase() : undefined;
+
+    const result: {
+      subject?: string;
+      avatarUrl?: string;
+      profileUrl?: string;
+      displayName?: string;
+    } = {
+      subject: fingerprint,
+      profileUrl: proofUrl,
+      displayName: "PGP Key",
+    };
+
+    // Extract avatar from GitHub gists
+    const gistMatch = proofUrl.match(/^https:\/\/gist\.github\.com\/([^/]+)\//);
+    if (gistMatch && data && typeof data === "object") {
+      const gist = data as { owner?: { avatar_url?: string; login?: string } };
+      if (gist.owner?.avatar_url) {
+        result.avatarUrl = gist.owner.avatar_url;
+      }
+    }
+
+    // Extract username from Tangled strings
+    const tangledMatch = proofUrl.match(/^https:\/\/tangled\.org\/strings\/([^/]+)\//);
+    if (tangledMatch) {
+      result.displayName = `PGP Key (${tangledMatch[1]})`;
+    }
+
+    return result;
+  },
+
+  getProofText(did) {
+    return `Verifying my PGP key on keytrace\n\ndid: ${did}\nfingerprint: {fingerprint}`;
+  },
+
+  getProofLocation() {
+    return "Host the clearsigned proof at a public URL (e.g. a GitHub Gist)";
+  },
+
+  tests: [
+    { uri: "pgp:https://gist.github.com/alice/abc123def456", shouldMatch: true },
+    { uri: "pgp:https://example.com/proof.txt", shouldMatch: true },
+    { uri: "pgp:https://tangled.org/strings/alice/abc123", shouldMatch: true },
+    { uri: "https://gist.github.com/alice/abc123", shouldMatch: false },
+    { uri: "pgp:http://example.com/proof.txt", shouldMatch: false },
+  ],
+};
+
+export default pgp;

--- a/packages/runner/src/serviceProviders/types.ts
+++ b/packages/runner/src/serviceProviders/types.ts
@@ -54,6 +54,22 @@ export interface ProcessedURI {
 }
 
 /**
+ * An additional input field for the add claim wizard (beyond the main claim URI)
+ */
+export interface ExtraInput {
+  /** Unique key used as placeholder in templates, e.g. "fingerprint" → {fingerprint} */
+  key: string;
+  /** Label displayed above the input */
+  label: string;
+  /** Placeholder text */
+  placeholder: string;
+  /** Optional regex pattern for validation */
+  pattern?: string;
+  /** Validation error message shown when pattern doesn't match */
+  patternError?: string;
+}
+
+/**
  * UI configuration for the add claim wizard
  */
 export interface ServiceProviderUI {
@@ -71,6 +87,8 @@ export interface ServiceProviderUI {
   instructions: string[];
   /** Template for proof content. Supports {did} and {handle} placeholders */
   proofTemplate: string;
+  /** Additional input fields beyond the main claim URI */
+  extraInputs?: ExtraInput[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a PGP service provider so users can prove ownership of a PGP key by clearsigning a proof message (containing their DID + fingerprint) and hosting it at a URL
- Supports GitHub Gists, Tangled Strings, and generic HTTPS URLs as proof hosting
- Adds a generic `ExtraInput` system to service providers, allowing the add wizard to collect additional fields beyond the main claim URI (used here for the PGP fingerprint)
- Profile cards show formatted fingerprints (4-char hex groups) and short key IDs
- Consolidates OAuth scopes to use full scope set for login