### PR TITLE
Bsky copy update 'description'

### DIFF
--- a/packages/runner/src/serviceProviders/bsky.ts
+++ b/packages/runner/src/serviceProviders/bsky.ts
@@ -27,7 +27,7 @@ const bsky: ServiceProvider = {
     inputLabel: "Profile or Post URL",
     inputPlaceholder: "https://bsky.app/profile/username.bsky.social",
     instructions: [
-      "**Option 1:** Add to your profile bio at [bsky.app](https://bsky.app) → **Profile** → **Edit Profile**",
+      "**Option 1:** Add to your profile description at [bsky.app](https://bsky.app) → **Profile** → **Edit Profile**",
       "**Option 2:** Create a post containing the verification content",
       "Copy the URL of your profile or post",
       "Paste the URL below",


### PR DESCRIPTION
<img width="1906" height="640" alt="image" src="https://github.com/user-attachments/assets/121a6b29-2a49-4a59-8804-cce596c43efc" />

Make the wording in the help text match what Bluesky use on their page (I'm guessing it's the "description" field the DID is supposed to be added to)